### PR TITLE
Enabled LUA syntax highlighting and slightly restructured text file opening.

### DIFF
--- a/WorldSmith/Documents/VirtualTextDocument.cs
+++ b/WorldSmith/Documents/VirtualTextDocument.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using WeifenLuo.WinFormsUI.Docking;
+using WorldSmith.Utils;
 
 namespace WorldSmith.Documents
 {
@@ -33,17 +34,19 @@ namespace WorldSmith.Documents
 
         public virtual TextEditor OpenTextEditor()
         {
+            Stopwatches.Watches["OpenTextEditor"].Start();
             bool EditorAlreadyOpen = ContainsEditor<TextEditor>();
             TextEditor editor = OpenEditor<TextEditor>();
             if (!EditorAlreadyOpen)
             {
-                editor.EditorStyle = TextEditor.TextEditorStyle.KeyValues;
                 editor.OpenDocument(this);
+                editor.UpdateEditorStyle();
                 editor.TabText = Name;
-
                 editor.Show(MainForm.PrimaryDockingPanel, DockState.Document);
             }
-
+            Stopwatches.Watches["OpenTextEditor"].Stop();
+            Console.WriteLine("Opened editor, taking {0} ms", Stopwatches.Watches["OpenTextEditor"].ElapsedMilliseconds);
+            Stopwatches.Watches["OpenTextEditor"].Reset();
             return editor;
         }
 

--- a/WorldSmith/Resources/LuaSyntax.xshd
+++ b/WorldSmith/Resources/LuaSyntax.xshd
@@ -1,10 +1,148 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<SyntaxDefinition name="Lua" extensions="*.lua">
+<SyntaxDefinition name="Lua" extensions=".lua">
+
+  <Properties>
+    <Property name="LineComment" value="--"/>
+  </Properties>
+
+  <Digits name="Digits" bold="false" italic="false" color="DarkBlue"/>
+
   <RuleSets>
     <RuleSet ignorecase="false">
-      <Span name="Comment" bold="false" italic="false" color="Green" stopateol="true">
+      <Delimiters>&amp;&lt;&gt;~!%^*()-+=|\/{}[]:;"' ,	.?</Delimiters>
+
+      <Span name="BlockComment" rule="CommentMarkerSet" bold="false" italic="false" color="Green" stopateol="false">
+        <Begin>--[[</Begin>
+        <End>]]</End>
+      </Span>
+      
+      <Span name="LineComment" rule="CommentMarkerSet" bold="false" italic="false" color="Green" stopateol="true">
         <Begin>--</Begin>
       </Span>
+
+      <Span name="Char" bold="false" italic="false" color="DarkBlue" stopateol="true" escapecharacter="\">
+        <Begin>&apos;</Begin>
+        <End>&apos;</End>
+      </Span>
+      
+
+      <Span name="String" bold="false" italic="false" color="DarkBlue" stopateol="false" escapecharacter="\">
+        <Begin>"</Begin>
+        <End>"</End>
+      </Span>
+
+      <Span name="MultiLineString" bold="false" italic="false" color="DarkBlue" stopateol="false" escapecharacter='"'>
+        <Begin>[[</Begin>
+        <End>]]</End>
+      </Span>
+
+      <!-- marks functions in bold -->
+      <MarkPrevious bold="true" italic="false" color="MidnightBlue">(</MarkPrevious>
+
+      <KeyWords name="Punctuation" bold="false" italic="false" color="DarkGreen">
+        <Key word="?" />
+        <Key word="," />
+        <Key word="." />
+        <Key word=";" />
+        <Key word="(" />
+        <Key word=")" />
+        <Key word="[" />
+        <Key word="]" />
+        <Key word="{" />
+        <Key word="}" />
+        <Key word="+" />
+        <Key word="-" />
+        <Key word="/" />
+        <Key word="%" />
+        <Key word="*" />
+        <Key word="&lt;" />
+        <Key word="&gt;" />
+        <Key word="^" />
+        <Key word="=" />
+        <Key word="~" />
+        <Key word="!" />
+        <Key word="|" />
+        <Key word="&amp;" />
+        <Key word="@" />
+        <Key word="$" />
+      </KeyWords>
+
+      <KeyWords name="CurrentKeywords" bold="true" italic="false" color="Blue">
+        <Key word="and"/>
+        <Key word="break"/>
+        <Key word="do"/>
+        <Key word="else"/>
+        <Key word="elseif"/>
+        <Key word="end"/>
+        <Key word="false"/>
+        <Key word="for"/>
+        <Key word="function"/>
+        <Key word="if"/>
+        <Key word="in"/>
+        <Key word="local"/>
+        <Key word="nil"/>
+        <Key word="not"/>
+        <Key word="or"/>
+        <Key word="repeat"/>
+        <Key word="return"/>
+        <Key word="then"/>
+        <Key word="true"/>
+        <Key word="until"/>
+        <Key word="while"/>
+        <Key word="print"/>
+        <Key word="collectgarbage" />
+        <Key word="type" />
+        <Key word="tostring" />
+        <Key word="tonumber" />
+        <Key word="print" />
+        <Key word="pairs" />
+        <Key word="ipairs" />
+        <Key word="next" />
+        <Key word="assert" />
+        <Key word="pcall" />
+        <Key word="xpcall" />
+        <Key word="error" />
+        <Key word="select" />
+        <Key word="dofile" />
+        <Key word="require" />
+        <Key word="openfile" />
+        <Key word="loadstring" />
+        <Key word="set" />
+        <Key word="loadfile" />
+        <Key word="wait" />
+        <Key word="rawset" />
+        <Key word="rawget" />
+        <Key word="getmetatable" />
+        <Key word="setmetatable" />
+        <Key word="ssave" />
+        <Key word="sload" />
+      </KeyWords>
+
+      <KeyWords name="Tables" bold="false" italic="false" color="DarkBlue">
+        <Key word="io"/>
+        <Key word="os"/>
+        <Key word="class" />
+        <Key word="table" />
+        <Key word="script" />
+        <Key word="file" />
+        <Key word="WinForms" />
+        <Key word="math" />
+        <Key word="console" />
+        <Key word="coroutine" />
+        <Key word="package" />
+        <Key word="string" />
+      </KeyWords>
+    </RuleSet>
+    <RuleSet name="CommentMarkerSet" ignorecase="false">
+      <Delimiters>&lt;&gt;~!@%^*()-+=|\#/{}[]:;"' ,	.?</Delimiters>
+      <KeyWords name="ErrorWords" bold="true" italic="false" color="Red">
+        <Key word="TODO" />
+        <Key word="FIXME" />
+      </KeyWords>
+      <KeyWords name="WarningWords" bold="true" italic="false" color="#EEE0E000">
+        <Key word="HACK" />
+        <Key word="UNDONE" />
+      </KeyWords>
     </RuleSet>
   </RuleSets>
 </SyntaxDefinition>

--- a/WorldSmith/Utils/Stopwatches.cs
+++ b/WorldSmith/Utils/Stopwatches.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WorldSmith.Utils
+{
+    /// <summary>
+    /// This class holds some named stopwatches to help in tracking down precise timings for performance critical sections of code.
+    /// </summary>
+    public class Stopwatches
+    {
+
+        private Stopwatches()
+        {
+            watches = new Dictionary<string, Stopwatch>();
+        }
+
+        private static Stopwatches _watches;
+        public static Stopwatches Watches
+        {
+            get
+            {
+                return _watches ?? (_watches = new Stopwatches());
+            }
+        }
+
+        private Dictionary<string, Stopwatch> watches;
+
+        private Stopwatch GetStopwatch(string name)
+        {
+            if (!watches.ContainsKey(name))
+            {
+                watches[name] = new Stopwatch();
+            }
+
+            return watches[name];
+        }
+
+        public Stopwatch this[string name]
+        {
+            get
+            {
+                return GetStopwatch(name);
+            }
+        }
+    }
+}

--- a/WorldSmith/WorldSmith.csproj
+++ b/WorldSmith/WorldSmith.csproj
@@ -352,6 +352,7 @@
     </Compile>
     <Compile Include="Themes\VS2012ToolStripExtender.Designer.cs" />
     <Compile Include="Themes\VS2012ToolStripRenderer.cs" />
+    <Compile Include="Utils\Stopwatches.cs" />
     <EmbeddedResource Include="Dialogs\AboutBox.resx">
       <DependentUpon>AboutBox.cs</DependentUpon>
     </EmbeddedResource>
@@ -455,12 +456,15 @@
     </Content>
     <Content Include="Resources\LuaSyntax.xshd">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <SubType>Designer</SubType>
     </Content>
     <EmbeddedResource Include="Resources\WorldsmithAbout.rtf" />
     <None Include="WorldSmith_TemporaryKey.pfx" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
+    <None Include="App.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\WSIcon32.png" />
@@ -526,6 +530,7 @@
     <None Include="Resources\dotaicon16x16.png" />
     <Content Include="Resources\SyntaxMode.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <SubType>Designer</SubType>
     </Content>
     <EmbeddedResource Include="Scripts\ObjectBrowserFolderOverride.txt" />
     <Content Include="WSIconic.ico" />


### PR DESCRIPTION
In the course of enabling LUA syntax highlighting, I converted the TextEditorStyle enum to a class to enable the usage of the "GetHighlightingStrategy" method to give the responsibility of which highlighter to use over to the TextEditorStyle entirely.

Additionally, added a utility class "Stopwatches" which allows easy access to gather timing information.

See example usage in VirtualTextDocument.cs .